### PR TITLE
fix: update tuns.sh domain

### DIFF
--- a/Dockerfile.tunnel
+++ b/Dockerfile.tunnel
@@ -9,4 +9,4 @@ ARG LOCAL_PORT=3434
 
 ENV SUBDOMAIN=$SUBDOMAIN REMOTE_PORT=$REMOTE_PORT LOCAL_HOST=$LOCAL_HOST LOCAL_PORT=$LOCAL_PORT
 
-ENTRYPOINT cp /root/.ssh/id_ed25519 /tmp/id_ed25519 && chmod 600 /tmp/id_ed25519 && exec autossh -M 0 -o StrictHostKeyChecking=accept-new -i /tmp/id_ed25519 -R ${SUBDOMAIN}:${REMOTE_PORT}:${LOCAL_HOST}:${LOCAL_PORT} tuns.sh
+ENTRYPOINT cp /root/.ssh/id_ed25519 /tmp/id_ed25519 && chmod 600 /tmp/id_ed25519 && exec autossh -M 0 -o StrictHostKeyChecking=accept-new -i /tmp/id_ed25519 -R ${SUBDOMAIN}:${REMOTE_PORT}:${LOCAL_HOST}:${LOCAL_PORT} nue.tuns.sh


### PR DESCRIPTION
Switch SSH tunnel target from `tuns.sh` to `nue.tuns.sh` after pico.sh decommissioned the US region (Ashburn).

Wildcard DNS for `*.tuns.sh` still points to the dead Ashburn server at `141.148.85.124`, while `nue.tuns.sh` (Nuremberg/Germany at `37.120.183.130`) is the only working region.

See: https://pico.sh/regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)